### PR TITLE
Avoid performance hit of detecting duplicate members if dups are allowed

### DIFF
--- a/s3_tar/s3_tar.py
+++ b/s3_tar/s3_tar.py
@@ -68,7 +68,7 @@ class S3Tar:
             self.part_size_multiplier = part_size_multiplier
 
         self.all_keys = set()  # Keys the user adds
-        self.keys_to_delete = set()  # Keys to delete one cleanup
+        self.keys_to_delete = set()  # Keys to delete on cleanup
         self.remove_keys = remove_keys
         self.file_cache = []  # io objects that are ready to be combined
         self.cache_size = cache_size
@@ -368,9 +368,9 @@ class S3Tar:
         if key_list is None:
             key_list = self.all_keys
 
-        if any((True for x in key_list
-                if tar_member_name == x[0] and key != x[1])):
-            if self.allow_dups is False:
+        if self.allow_dups is False:
+            if any((True for x in key_list
+                    if tar_member_name == x[0] and key != x[1])):
                 raise ValueError(("Filename '{member_name}' for key '{key}'"
                                   " already exists in the tar file."
                                   " Set allow_dups to continue.")


### PR DESCRIPTION
This is a pretty simple fix that just makes the code not run the expensive check for duplicates if I am just going to discard the result of the check anyway. 

I get that it is possible that some people will want to add files with the same member name but different contents to mirror that functionality in tar archives, but having to run through every member to check every time a file is added gets super expensive super quickly. I haven't managed to think of a better way to do it after a cursory glance through the code, but just think that its current implementation needs some more thought. This library is really useful otherwise but just this check seems to scale poorly once you try to use it with a prefix containing millions of files.