### PR TITLE
flush and seek in _download_source_file()

### DIFF
--- a/s3_tar/s3_tar.py
+++ b/s3_tar/s3_tar.py
@@ -308,6 +308,12 @@ class S3Tar:
         """
         source_key_io = io.BytesIO()
         self.s3.download_fileobj(self.source_bucket, key, source_key_io)
+                
+        # Maybe necessary to flush and seek to the EOF,
+        # see https://github.com/boto/boto3/issues/1304
+        source_key_io.flush()
+        source_key_io.seek(0, 2)
+        
         return source_key_io
 
     def _download_source_metadata(self, key):


### PR DESCRIPTION
Observed truncation of large files inserted into archive. It seems necessary to flush and seek to the EOF of  `source_key_io` to avoid this, see https://github.com/boto/boto3/issues/1304.  As this Boto issue indicates, multipart downloads (with threaded transfers?) make the file `tell()` position somewhat indeterminate at times. Flushing the file and seeking to the end, appears to repair this problem. Otherwise, **TarInfo** in `_save_bytes_to_tar` will be given the wrong size for its files.